### PR TITLE
Update client.go

### DIFF
--- a/json/client.go
+++ b/json/client.go
@@ -22,7 +22,7 @@ type clientRequest struct {
 	// A String containing the name of the method to be invoked.
 	Method string `json:"method"`
 	// Object to pass as request parameter to the method.
-	Params [1]interface{} `json:"params"`
+	Params interface{} `json:"params"`
 	// The request id. This can be of any type. It is used to match the
 	// response with the request that it is replying to.
 	Id uint64 `json:"id"`
@@ -36,10 +36,10 @@ type clientResponse struct {
 }
 
 // EncodeClientRequest encodes parameters for a JSON-RPC client request.
-func EncodeClientRequest(method string, args interface{}) ([]byte, error) {
+func EncodeClientRequest(method string, args ...interface{}) ([]byte, error) {
 	c := &clientRequest{
 		Method: method,
-		Params: [1]interface{}{args},
+		Params: args,
 		Id:     uint64(rand.Int63()),
 	}
 	return json.Marshal(c)


### PR DESCRIPTION
This little change can eliminate the restriction of the number of input params must be one( which from golang built-in rpc package becasue clientRequest.Params is define as [1]interface{}). So this can be much more general to other languages' json-rpc implements.
